### PR TITLE
Fix text color when activating the os dark theme

### DIFF
--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -156,6 +156,10 @@ class Log(InterfaceView):
         self.stop_on_copy = False
         self.revision_clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
+        style = self.get_widget("revisions_table").get_style_context()
+        textcolor = style.get_color(Gtk.StateFlags.NORMAL)
+        self.orgTextColor = textcolor.to_string()
+
     #
     # UI Signal Callback Methods
     #
@@ -486,7 +490,7 @@ class SVNLog(Log):
         for item in self.display_items:
             msg = helper.format_long_text(item.message, cols = 80, line1only = True)
             rev = item.revision
-            color = "#000000"
+            color = self.orgTextColor #"#000000"
             if (self.merge_candidate_revisions != None and
                 int(rev.short()) not in self.merge_candidate_revisions):
                 color = "#c9c9c9"


### PR DESCRIPTION
The font color was always set to black, even when using the os dark theme. However in this case the text was no longer readable.